### PR TITLE
Linux fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function watchFallback (directory, onchange) {
   var watching = {}
   var loaded = false
   var queued = []
-  var prevs = new Cache({ttl: 2e3, capacity: 30
+  var prevs = new Cache({ttl: 2e3, capacity: 30})
 
   visit('.', function () {
     loaded = true

--- a/index.js
+++ b/index.js
@@ -140,9 +140,9 @@ function same (a, b) {
     a.rdev === b.rdev &&
     a.blksize === b.blksize &&
     a.ino === b.ino &&
-    a.size === b.size &&
-    a.blocks === b.blocks &&
+    // a.size === b.size && DONT TEST - is a lying value
+    // a.blocks === b.blocks && DONT TEST - is a lying value
     a.atime.getTime() === b.atime.getTime() &&
-    a.mtime.getTime() === b.atime.getTime() &&
+    a.mtime.getTime() === b.mtime.getTime() &&
     a.ctime.getTime() === b.ctime.getTime()
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.1.1",
   "description": "Minimal recursive file watcher",
   "main": "index.js",
-  "dependencies": {},
+  "dependencies": {
+    "ttl": "^1.3.0"
+  },
   "devDependencies": {
     "standard": "^8.6.0"
   },


### PR DESCRIPTION
 1. Dont compare size & blocks on linux; some of the watch event fires seem to be prior to a flush, causing the size and block to report as `0`. Then it fires again with non-zero values, causing a false positive.
 2. Use an expiring cache to track deduplications in linux. That trades a small bit of memory overhead to improve correctness.