### PR TITLE
Don't let it call clear() when file doesn't exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,10 @@ function watch (name, onchange) {
   var stopped = false
 
   fs.lstat(name, function (_, st) {
-    if (!st || stopped) return
+    if (!st || stopped) {
+      stopped = true
+      return
+    }
     clear = st.isDirectory() ? watchDirectory(name, onchange) : watchFile(name, onchange)
   })
 


### PR DESCRIPTION
Heya,
If you give it a bogus file path (!st), it still returns that function that calls `clear()`, but if you call it, `clear` is not defined. This just blocks that. Should I make a test or something? The `mirror-folder` tests passed with this. 

I was trying to make watchify use this instead of chokidar, and for some reason(?), the test suite tries to watch a bunch of package.json's that don't exist. 