### PR TITLE
Handle case when filename is null in fs.watch cb

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,9 @@ function watchFile (filename, onchange) {
 
 function watchRecursive (directory, onchange) {
   var w = fs.watch(directory, {recursive: true}, function (change, filename) {
-    onchange(path.join(directory, filename))
+    if (filename) {
+      onchange(path.join(directory, filename))
+    }
   })
 
   return function () {


### PR DESCRIPTION
It's possible for the `fs.watch` callback to be called with a nully filename. This will pass through to `path.join`, and since `path.join` can't handle non-string values, this will result in an error.

[doc](https://nodejs.org/api/fs.html#fs_filename_argument)