### PR TITLE
Fix error if no filename

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ function watchFile (filename, onchange) {
 
 function watchRecursive (directory, onchange) {
   var w = fs.watch(directory, {recursive: true}, function (change, filename) {
+    if (!filename) return // filename not always given (https://nodejs.org/api/fs.html#fs_filename_argument)
     onchange(path.join(directory, filename))
   })
 


### PR DESCRIPTION
Filename on `fs.watch` can be null. This causes Dat to crash: https://github.com/datproject/dat/issues/964. Seems like it happens on rename sometimes for windows, see node docs note: https://nodejs.org/api/fs.html#fs_filename_argument

Make sure we have filename before calling `onchange` event. I assume we shouldn't call `onchange` without a filename?