### PR TITLE
Add Support for Android (Linux Based)

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ var fs = require('fs')
 var path = require('path')
 var Cache = require('ttl')
 
-var isLinux = os.platform() === 'linux' // native recursive watching not supported here
-var watchDirectory = isLinux ? watchFallback : watchRecursive
+var isLinuxBased = os.platform() === 'linux' || os.platform() === 'android' // native recursive watching not supported here
+var watchDirectory = isLinuxBased ? watchFallback : watchRecursive
 
 module.exports = watch
 


### PR DESCRIPTION
This module is very underrated recursive file watching. Currently i use this in my app which need a callback for file changes also running a static server with express.static(), but using fs cant watch subdirectories, and nodemon always restart my local server in the same port which causing errors, so this is alternative.

But doesn't include android platform which is linux based, but now i added it, i already tested it and works great.

Please accept this PR 🙏